### PR TITLE
fix: remove debug print statement from set_smtp method

### DIFF
--- a/src/spaceone/notification/connector/smtp.py
+++ b/src/spaceone/notification/connector/smtp.py
@@ -17,7 +17,6 @@ class SMTPConnector(BaseConnector):
         self.smtp = None
 
     def set_smtp(self, host, port, user, password):
-        print(f'$$$ host: {host}, port: {port}, user: {user}, password: {password}')
         self.smtp = smtplib.SMTP(host, port)
         self.smtp.connect(host, port)
         self.smtp.ehlo()


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Refactor
- [o] etc

### Description
- fix: remove debug print statement from set_smtp method
### Known issue